### PR TITLE
feat: Add entry for GH repo link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,6 @@
 
 ## Thunderstore link
 <YOUR_MODS_THUNDERSTORE_WEBPAGE_LINK_HERE>
+
+## GitHub repo link
+<YOUR_MODS_GITHUB_REPO_LINK_HERE>


### PR DESCRIPTION
(Meta PR, this does not add any mod for verification)

Adds an entry for the repo pull request link. This is done to avoid having to hunt down the repo link on Thunderstore page