### PR TITLE
build: Commit verification

### DIFF
--- a/.github/verify_versions.py
+++ b/.github/verify_versions.py
@@ -1,0 +1,32 @@
+import sys
+from urllib.request import urlopen
+import json
+
+# Load local manifesto file
+f = open('verified-mods.json')
+manifesto = json.load(f)
+
+for mod in manifesto:
+    print('Verifying "{}":'.format(mod))
+
+    # Build GitHub API link and fetch distant tags list
+    words = manifesto[mod]['Repository'].split('/')
+    tags_url = "https://api.github.com/repos/{}/{}/tags".format(words[-2], words[-1])
+    response = urlopen(tags_url) 
+    tags_data = json.loads(response.read())
+
+    # Check all mod versions one-by-one
+    for version in manifesto[mod]['Versions']:
+        local_hash = version['CommitHash']
+        matching_distant_versions = list(filter(lambda v: v['name'] == version['Version'], tags_data))
+
+        # There should be only one matching version
+        if len(matching_distant_versions) != 1:
+            sys.exit('  ❌ v{} (unknown distant version)'.format(version['Version']))
+        
+        # Compare manifesto commit hash with repository hash
+        distant_version = matching_distant_versions[0]
+        if local_hash == distant_version['commit']['sha']:
+            print('  ✔️ v{}'.format(version['Version']))
+        else:
+            sys.exit('  ❌ v{} (hash comparison failed)'.format(version['Version']))

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,3 +12,14 @@ jobs:
         with:
             file: 'verified-mods.json'
             schema: '.github/schema.json'
+  verify-mods-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+      - name: Run mod checks
+        run: |
+          python .github/verify_versions.py

--- a/verified-mods.json
+++ b/verified-mods.json
@@ -4,7 +4,7 @@
         "Repository": "https://github.com/uniboi/s2space",
         "Versions": [
             {
-                "Version": "0.0.4",
+                "Version": "0.0.5",
                 "CommitHash": "f27b8f1f05d5278aa8f47ead2d9e70f39f274173",
                 "Checksum": "670987e07806e8dffcb591bad8724f29abc18d9baa304d9ab4fae7804bd86bc2"
             }


### PR DESCRIPTION
**META PR, NO MOD VERIFICATION NEEDED**

This PR introduces a Python script that runs additional verification on the `verified-mods.json` file, checking that each mod version really exists on GitHub, and that associated commit hash is valid.

### GitHub Action runs:

**Wrong version example:** https://github.com/Alystrasz/VerifiedMods/actions/runs/7066178952/job/19237582365
**Good version example:** https://github.com/Alystrasz/VerifiedMods/actions/runs/7066231816/job/19237726616