### PR TITLE
Add a RestartRequired field to the Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This verified mods enables players to join servers that require custom content s
 
 Verified mods are listed in the present `verified-mods.json` file, using following format:
 * Key is mod's name (contained in its `mod.json` manifest's "Name" key);
-* Body holds three fields:
+* Body holds four fields:
   * "DependencyPrefix" contains the string that allows Northstar to retrieve mods on Thunderstore;
   * "Repository" contains the link of the repository hosting the source code of the mod;
-  * "Versions" contains a list of version (for the current mod) that have been verified.
+  * "Versions" contains a list of version (for the current mod) that have been verified;
+  * "RequiresRestart" contains a boolean for if the mod requires a game restart to be loaded properly.
 
 ## How to submit a mod for verification
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ This verified mods enables players to join servers that require custom content s
 
 Verified mods are listed in the present `verified-mods.json` file, using following format:
 * Key is mod's name (contained in its `mod.json` manifest's "Name" key);
-* Body holds four fields:
+* Body holds three fields:
   * "DependencyPrefix" contains the string that allows Northstar to retrieve mods on Thunderstore;
   * "Repository" contains the link of the repository hosting the source code of the mod;
-  * "Versions" contains a list of version (for the current mod) that have been verified;
-  * "RequiresRestart" contains a boolean for if the mod requires a game restart to be loaded properly.
+  * "Versions" contains a list of version (for the current mod) that have been verified.
 
 ## How to submit a mod for verification
 

--- a/verified-mods.json
+++ b/verified-mods.json
@@ -6,9 +6,9 @@
             {
                 "Version": "0.0.5",
                 "CommitHash": "f27b8f1f05d5278aa8f47ead2d9e70f39f274173",
-                "Checksum": "670987e07806e8dffcb591bad8724f29abc18d9baa304d9ab4fae7804bd86bc2"
+                "Checksum": "670987e07806e8dffcb591bad8724f29abc18d9baa304d9ab4fae7804bd86bc2",
+                "RequiresRestart": false
             }
-        ],
-        "RequiresRestart": false
+        ]
     }
 }

--- a/verified-mods.json
+++ b/verified-mods.json
@@ -8,6 +8,7 @@
                 "CommitHash": "f27b8f1f05d5278aa8f47ead2d9e70f39f274173",
                 "Checksum": "670987e07806e8dffcb591bad8724f29abc18d9baa304d9ab4fae7804bd86bc2"
             }
-        ]
+        ],
+        "RequiresRestart": false
     }
 }


### PR DESCRIPTION
## meta PR, no verification needed

Adds a new field to a verified mod's version, will be used in launcher to determine if the game needs to be restarted to load the mod properly. (helps for things like models which need a game restart to load)