### PR TITLE
ci: Bump checkout action to v4

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ jobs:
   verify-json-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Validate package.json against local schema
         uses: cardinalby/schema-validator-action@v3
         with:
@@ -15,7 +15,7 @@ jobs:
   verify-mods-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
**META PR, NO MOD VERIFICATION NEEDED**

Bumps the [`actions/checkout`](https://github.com/actions/checkout) action to `v4`

This is being done as currently CI is warning us that Node version that current `checkout` action is using will be deprecated.

![image](https://github.com/R2Northstar/VerifiedMods/assets/40122905/99c0e4a5-76f1-4e45-8ab4-71bb04d86d60)
