### PR TITLE
ci: Bump setup-python to v5

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Run mod checks


### PR DESCRIPTION
**META PR, NO MOD VERIFICATION NEEDED**

Bumps the [`actions/setup-python`](https://github.com/actions/setup-python) action to `v5`

This is being done as currently CI is warning us that Node version that current `setup-python` action is using will be deprecated.

![image](https://github.com/R2Northstar/VerifiedMods/assets/40122905/99c0e4a5-76f1-4e45-8ab4-71bb04d86d60)
