### PR TITLE
feat: Adjust JSON structure to allow for other mod sources (but better)

### DIFF
--- a/.github/schema.json
+++ b/.github/schema.json
@@ -35,6 +35,9 @@
                             "DownloadLink": {
                                 "type": "string",
                                 "pattern": "^https://"
+                            },
+                            "Platform": {
+                                "enum": [ "thunderstore" ]
                             }
                         },
                         "required": [ "Version", "Checksum", "CommitHash", "DownloadLink" ]

--- a/.github/schema.json
+++ b/.github/schema.json
@@ -7,10 +7,6 @@
         "^[A-Za-z._0-9]+": {
             "type": "object",
             "properties": {
-                "DependencyPrefix": {
-                    "type": "string",
-                    "pattern": "^([A-Za-z._0-9]+)-([A-Za-z._0-9]+)$"
-                },
                 "Repository": {
                     "type": "string",
                     "pattern": "^https://"

--- a/.github/schema.json
+++ b/.github/schema.json
@@ -31,9 +31,13 @@
                                 "pattern": "^([0-9a-f]+)$",
                                 "minLength": 40,
                                 "maxLength": 40
-                          }
+                            },
+                            "DownloadLink": {
+                                "type": "string",
+                                "pattern": "^https://"
+                            }
                         },
-                        "required": [ "Version", "Checksum", "CommitHash" ]
+                        "required": [ "Version", "Checksum", "CommitHash", "DownloadLink" ]
                     }
                 }
             },

--- a/.github/schema.json
+++ b/.github/schema.json
@@ -41,7 +41,7 @@
                     }
                 }
             },
-            "required": [ "DependencyPrefix", "Repository", "Versions" ]
+            "required": [ "Repository", "Versions" ]
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ This verified mods enables players to join servers that require custom content s
 
 Verified mods are listed in the present `verified-mods.json` file, using following format:
 * Key is mod's name (contained in its `mod.json` manifest's "Name" key);
-* Body holds three fields:
-  * "DependencyPrefix" contains the string that allows Northstar to retrieve mods on Thunderstore;
+* Body holds two fields:
   * "Repository" contains the link of the repository hosting the source code of the mod;
   * "Versions" contains a list of version (for the current mod) that have been verified.
+
+Each version contains the following attributes:
+* "Version" is the current version identifier (using the `x.y.z` format);
+* "CommitHash" is the Git commit associated to the current version;
+* "DownloadLink" is the direct download link of the version archive;
+* "Checksum" is the SHA256 hash of the version archive;
+* "Platform" is the origin of the version ("thunderstore" is currently the only supported option).
 
 ## How to submit a mod for verification
 

--- a/verified-mods.json
+++ b/verified-mods.json
@@ -6,7 +6,8 @@
                 "Version": "0.0.5",
                 "CommitHash": "f27b8f1f05d5278aa8f47ead2d9e70f39f274173",
                 "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/odds-s2space-0.0.5.zip",
-                "Checksum": "670987e07806e8dffcb591bad8724f29abc18d9baa304d9ab4fae7804bd86bc2"
+                "Checksum": "670987e07806e8dffcb591bad8724f29abc18d9baa304d9ab4fae7804bd86bc2",
+                "Platform": "thunderstore"
             }
         ]
     },
@@ -17,7 +18,8 @@
                 "Version": "0.2.1",
                 "CommitHash": "0eca593ac1666aeeaa061a5c545d917d47d6d113",
                 "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/Alystrasz-Parkour-0.2.1.zip",
-                "Checksum": "eef8ae5a88df68b249529f31713d0219b18391202dfeedc2d109936c729c571c"
+                "Checksum": "eef8ae5a88df68b249529f31713d0219b18391202dfeedc2d109936c729c571c",
+                "Platform": "thunderstore"
             }
         ]
     },
@@ -28,7 +30,8 @@
                 "Version": "1.0.9",
                 "CommitHash": "f8353281b8daf6a94cfb4bc04c9ced0635e58c37",
                 "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/Dinorush-LTS_Rebalance-1.0.9.zip",
-                "Checksum": "ec19938e44872c02c618190880a60fddbf2ea04ef8c09b0fd1bb246e5607880f"
+                "Checksum": "ec19938e44872c02c618190880a60fddbf2ea04ef8c09b0fd1bb246e5607880f",
+                "Platform": "thunderstore"
             }
         ]
     },
@@ -39,13 +42,15 @@
                 "Version": "1.0.0",
                 "CommitHash": "01fb15e22f62855cdcc2d87e3b52fa71d3401446",
                 "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/x3Karma-HotPotato-1.0.0.zip",
-                "Checksum": "d83f39a63c0ab7d886d23605a7b3310d0cd4260c77159eb71c8cbccce963cec2"
+                "Checksum": "d83f39a63c0ab7d886d23605a7b3310d0cd4260c77159eb71c8cbccce963cec2",
+                "Platform": "thunderstore"
             },
             {
                 "Version": "1.1.0",
                 "CommitHash": "72a1f00602e0643877688f065d0124e1f2397c5e",
                 "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/x3Karma-HotPotato-1.1.0.zip",
-                "Checksum": "e2fa138cc22b7a576b2a5f0dbe7a489448edce331b06d9c5430abbc36ad41078"
+                "Checksum": "e2fa138cc22b7a576b2a5f0dbe7a489448edce331b06d9c5430abbc36ad41078",
+                "Platform": "thunderstore"
             }
         ]
     },
@@ -56,7 +61,8 @@
                 "Version": "1.0.2",
                 "CommitHash": "38ff920639dc6556a039808770b5470122494a47",
                 "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/Nyami11-mp_brick-1.0.2.zip",
-                "Checksum": "6eeae287c4cdd7b79e07366828940282952b82738a6dd97c3cf3ad35e0858d9f"
+                "Checksum": "6eeae287c4cdd7b79e07366828940282952b82738a6dd97c3cf3ad35e0858d9f",
+                "Platform": "thunderstore"
             }
         ]
     }

--- a/verified-mods.json
+++ b/verified-mods.json
@@ -1,60 +1,61 @@
 {
     "Odd.s2space": {
-        "DependencyPrefix": "odds-s2space",
         "Repository": "https://github.com/uniboi/s2space",
         "Versions": [
             {
                 "Version": "0.0.5",
                 "CommitHash": "f27b8f1f05d5278aa8f47ead2d9e70f39f274173",
+                "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/odds-s2space-0.0.5.zip",
                 "Checksum": "670987e07806e8dffcb591bad8724f29abc18d9baa304d9ab4fae7804bd86bc2"
             }
         ]
     },
     "Parkour": {
-        "DependencyPrefix": "Alystrasz-Parkour",
         "Repository": "https://github.com/Alystrasz/Alystrasz.Parkour",
         "Versions": [
             {
                 "Version": "0.2.1",
                 "CommitHash": "0eca593ac1666aeeaa061a5c545d917d47d6d113",
+                "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/Alystrasz-Parkour-0.2.1.zip",
                 "Checksum": "eef8ae5a88df68b249529f31713d0219b18391202dfeedc2d109936c729c571c"
             }
         ]
     },
     "Dinorush's LTS Rebalance": {
-        "DependencyPrefix": "Dinorush-LTS_Rebalance",
         "Repository": "https://github.com/Dinorush/LTSRebalance",
         "Versions": [
             {
                 "Version": "1.0.9",
                 "CommitHash": "f8353281b8daf6a94cfb4bc04c9ced0635e58c37",
+                "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/Dinorush-LTS_Rebalance-1.0.9.zip",
                 "Checksum": "ec19938e44872c02c618190880a60fddbf2ea04ef8c09b0fd1bb246e5607880f"
             }
         ]
     },
     "HotPotato": {
-        "DependencyPrefix": "x3Karma-HotPotato",
         "Repository": "https://github.com/x3Karma/HotPotato",
         "Versions": [
             {
                 "Version": "1.0.0",
                 "CommitHash": "01fb15e22f62855cdcc2d87e3b52fa71d3401446",
+                "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/x3Karma-HotPotato-1.0.0.zip",
                 "Checksum": "d83f39a63c0ab7d886d23605a7b3310d0cd4260c77159eb71c8cbccce963cec2"
             },
             {
                 "Version": "1.1.0",
                 "CommitHash": "72a1f00602e0643877688f065d0124e1f2397c5e",
+                "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/x3Karma-HotPotato-1.1.0.zip",
                 "Checksum": "e2fa138cc22b7a576b2a5f0dbe7a489448edce331b06d9c5430abbc36ad41078"
             }
         ]
     },
     "nyami.mp_brick": {
-        "DependencyPrefix": "Nyami11-mp_brick",
         "Repository": "https://github.com/Nyami11/mp_brick",
         "Versions": [
             {
                 "Version": "1.0.2",
                 "CommitHash": "38ff920639dc6556a039808770b5470122494a47",
+                "DownloadLink": "https://gcdn.thunderstore.io/live/repository/packages/Nyami11-mp_brick-1.0.2.zip",
                 "Checksum": "6eeae287c4cdd7b79e07366828940282952b82738a6dd97c3cf3ad35e0858d9f"
             }
         ]


### PR DESCRIPTION
**META PR, no verification needed (although it does touch `verified-mods.json`, so give it a double check nevertheless)**

The idea here is to remove the dependency to Thunderstore and allow downloading mods from other platforms.

Closes #22.

##### TODOs

- [x] Launcher PR (https://github.com/R2Northstar/NorthstarLauncher/pull/748)
- [x] CI update